### PR TITLE
The float terminal is now named decimal

### DIFF
--- a/lib/process-doc.js
+++ b/lib/process-doc.js
@@ -7,7 +7,7 @@ module.exports = document => {
             if (/^"/.test(m)) {
                 return `<emu-t>${m.replace(/^"|"$/g, "")}</emu-t>`;
             }
-            if (/^(integer|float|identifier|string|whitespace|comment|other)$/.test(m)) {
+            if (/^(integer|decimal|identifier|string|whitespace|comment|other)$/.test(m)) {
               return `<emu-t class="regex"><a href="#prod-${m}">${m}</a></emu-t>`;
             }
             if (m == ":") {


### PR DESCRIPTION
Although this script appears to be embedded in the Web IDL repo proper and it has this change, this repo seems to be what’s actually being used to generate the html document. As a consequence, usage of the decimal regex terminal in grammar defs gets rendered as a non-terminal:

![image](https://user-images.githubusercontent.com/6257356/66344326-8cf89180-e91b-11e9-83f4-ca9366b9297b.png)
